### PR TITLE
Lay groundwork for PicoBot package structure

### DIFF
--- a/picobot/__init__.py
+++ b/picobot/__init__.py
@@ -1,0 +1,13 @@
+"""PicoBot package exposing the GUI application and related services."""
+
+from __future__ import annotations
+
+__all__ = ["main"]
+
+
+def main() -> None:
+    """Launch the PicoBot GUI application."""
+
+    from .app import main as _app_main
+
+    _app_main()

--- a/picobot/__main__.py
+++ b/picobot/__main__.py
@@ -1,0 +1,7 @@
+"""Run the PicoBot GUI via ``python -m picobot``."""
+
+from .app import main
+
+
+if __name__ == "__main__":
+    main()

--- a/picobot/app.py
+++ b/picobot/app.py
@@ -9,7 +9,6 @@ from tkinter import filedialog, messagebox, ttk
 from tkinter.scrolledtext import ScrolledText
 
 import pygetwindow as gw
-import requests
 import serial
 import serial.tools.list_ports
 import asyncio
@@ -22,38 +21,8 @@ except Exception:
     websockets = None
 from http.server import HTTPServer, BaseHTTPRequestHandler
 
-CONFIG_FILE = "config.json"
-
-
-class TelegramHandler:
-    """Handles sending messages via Telegram API."""
-
-    def __init__(self, bot_token, chat_id):
-        """Initializes the Telegram handler with bot token and chat ID.
-
-        Args:
-            bot_token (str): The Telegram bot token for authentication.
-            chat_id (str): The chat ID where messages will be sent.
-        """
-        self.bot_token = bot_token
-        self.chat_id = chat_id
-
-    def send_message(self, text):
-        """Sends a message to the configured Telegram chat.
-
-        Args:
-            text (str): The message text to send.
-        """
-        url = f"https://api.telegram.org/bot{self.bot_token}/sendMessage"
-        params = {"chat_id": self.chat_id, "text": text}
-        try:
-            response = requests.post(url, params=params)
-            if response.status_code == 200:
-                logging.info("Telegram message sent successfully.")
-            else:
-                logging.error(f"Failed to send message: {response.text}")
-        except Exception as e:
-            logging.error(f"Error sending Telegram message: {e}")
+from .messaging import TelegramHandler
+from .settings import CONFIG_FILE, configure_logging
 
 
 class RemoteControlServer:
@@ -2189,7 +2158,14 @@ class MacroControllerApp:
             self.save_config()
 
 
-if __name__ == "__main__":
+def main() -> None:
+    """Launch the PicoBot GUI application."""
+
+    configure_logging()
     root = tk.Tk()
     app = MacroControllerApp(root)
     root.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/picobot/messaging.py
+++ b/picobot/messaging.py
@@ -1,0 +1,40 @@
+"""Messaging helpers for PicoBot."""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import requests
+
+
+logger = logging.getLogger(__name__)
+
+
+class TelegramHandler:
+    """Handles sending messages via the Telegram Bot API."""
+
+    def __init__(self, bot_token: str, chat_id: str) -> None:
+        self.bot_token = bot_token
+        self.chat_id = chat_id
+
+    def send_message(self, text: str) -> Optional[requests.Response]:
+        """Send *text* to the configured chat."""
+
+        if not self.bot_token or not self.chat_id:
+            logger.debug("Telegram credentials are not configured; skipping send.")
+            return None
+
+        url = f"https://api.telegram.org/bot{self.bot_token}/sendMessage"
+        params = {"chat_id": self.chat_id, "text": text}
+        try:
+            response = requests.post(url, params=params, timeout=10)
+        except Exception as exc:  # pragma: no cover - network errors aren't deterministic
+            logger.error("Error sending Telegram message: %s", exc)
+            return None
+
+        if response.status_code == 200:
+            logger.info("Telegram message sent successfully.")
+        else:
+            logger.error("Failed to send message: %s", response.text)
+        return response

--- a/picobot/playback/__init__.py
+++ b/picobot/playback/__init__.py
@@ -1,0 +1,1 @@
+"""Macro playback orchestration for PicoBot."""

--- a/picobot/settings.py
+++ b/picobot/settings.py
@@ -1,0 +1,21 @@
+"""Configuration helpers and shared constants for PicoBot."""
+
+from __future__ import annotations
+
+import logging
+
+CONFIG_FILE = "config.json"
+LOG_LEVEL = logging.INFO
+LOG_FORMAT = "%(asctime)s - %(levelname)s - %(message)s"
+
+
+def configure_logging(*, level: int = LOG_LEVEL, fmt: str = LOG_FORMAT, force: bool = False) -> None:
+    """Initialize the root logger used across PicoBot."""
+
+    if force:
+        logging.basicConfig(level=level, format=fmt, force=True)
+        return
+
+    if logging.getLogger().handlers:
+        return
+    logging.basicConfig(level=level, format=fmt)

--- a/picobot/transport/__init__.py
+++ b/picobot/transport/__init__.py
@@ -1,0 +1,1 @@
+"""Transport layer abstractions for PicoBot."""

--- a/picobot/ui/__init__.py
+++ b/picobot/ui/__init__.py
@@ -1,0 +1,1 @@
+"""User interface components for PicoBot."""


### PR DESCRIPTION
## Summary
- reorganized the monolithic script into a `picobot` package with the GUI entry point now living in `picobot/app.py`
- extracted the Telegram messaging helper and shared configuration into dedicated `messaging` and `settings` modules
- stubbed transport, playback, and UI subpackages plus a `__main__` launcher to support future modularization work

## Testing
- python -m compileall picobot

------
https://chatgpt.com/codex/tasks/task_e_68d3aadc9a248326aa326ae8d544365d